### PR TITLE
fix: hover ts comment Object error

### DIFF
--- a/common/changes/@coze-editor/code-language-typescript/main_2025-10-20-06-34.json
+++ b/common/changes/@coze-editor/code-language-typescript/main_2025-10-20-06-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze-editor/code-language-typescript",
+      "comment": "hover ts comment Object error",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@coze-editor/code-language-typescript",
+  "email": "zhangyi.hanchayi@bytedance.com"
+}

--- a/packages/text-editor/code-language-typescript/src/worker.ts
+++ b/packages/text-editor/code-language-typescript/src/worker.ts
@@ -175,6 +175,10 @@ class TypeScriptWorker implements ITypeScriptWorker {
       return null;
     }
 
+    if (node === sourceFile) {
+      return null;
+    }
+
     const type = checker.getTypeAtLocation(node);
 
     if (!type.isClassOrInterface()) {


### PR DESCRIPTION
### Changes
- fix: error when cursor hover on an Object in comment

#### The error code 

``` typescript
import { Args } from '@/runtime';
import { Input, Output } from "@/typings/a/a";
import {} from '@/typings'

/**
  * Each file needs to export a function named `handler`. This function is the entrance to the Tool.
  * @param {Object} args.input - input parameters, you can get test input value by input.xxx.
  * @param {Object} args.logger - logger instance used to print logs, injected by runtime
  * @returns {*} The return data of the function, which should match the declared output parameters.
  *
  * Remember to fill in input/output in Metadata, it helps LLM to recognize and use tool.
  */
export async function handler({ input, logger }: Args<Input>): Promise<Output> {
  console.log('sdf', 's')
  return {
    message: "Hello, world!",
  };
};
```

#### The error

<img width="1766" height="1712" alt="image" src="https://github.com/user-attachments/assets/eac1517f-1c8e-4502-83f0-a3dd592c79b6" />
