### PR TITLE
fix: async syntax colorization

### DIFF
--- a/common/changes/@coze-editor/extensions/fix-line-comment-color_2025-12-19-08-53.json
+++ b/common/changes/@coze-editor/extensions/fix-line-comment-color_2025-12-19-08-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze-editor/extensions",
+      "comment": "async sytax colorization",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@coze-editor/extensions",
+  "email": "zhangyi.hanchayi@bytedance.com"
+}

--- a/packages/text-editor/extensions/src/brackets/colorization.ts
+++ b/packages/text-editor/extensions/src/brackets/colorization.ts
@@ -8,7 +8,7 @@ import {
   type ViewUpdate,
   type DecorationSet,
 } from '@codemirror/view';
-import { syntaxTree } from '@codemirror/language';
+import { syntaxTree, syntaxTreeAvailable } from '@codemirror/language';
 
 const DEFAULT_COLORS = ['#ffd700', '#da70d6', '#179fff'];
 
@@ -21,9 +21,21 @@ const ColorizationBracketsPlugin = ViewPlugin.fromClass(
     }
 
     update(update: ViewUpdate) {
-      if (update.docChanged || update.selectionSet || update.viewportChanged) {
+      if (
+        update.docChanged ||
+        update.selectionSet ||
+        update.viewportChanged ||
+        this.syntaxTreeAvailableChanged(update)
+      ) {
         this.decorations = this.getBracketDecorations(update.view);
       }
+    }
+
+    syntaxTreeAvailableChanged(update: ViewUpdate) {
+      return (
+        !syntaxTreeAvailable(update.startState) &&
+        syntaxTreeAvailable(update.state)
+      );
     }
 
     getBracketDecorations(view: EditorView) {


### PR DESCRIPTION
### 修改点
- 修复异步加载语言包首次进入注释中括号颜色

### 现象
- 首次进入时 注释中的 {} 依然有颜色，变更或者选中时变成注释的颜色

### 根因
- 由于语言包是异步加载的，首次进入syntaxTree还没有所以没法根据语法树中的类型去屏蔽注释颜色