### PR TITLE
fix: async syntax colorization

### DIFF
--- a/common/changes/@coze-editor/extensions/fix-async-colorization_2025-12-19-10-11.json
+++ b/common/changes/@coze-editor/extensions/fix-async-colorization_2025-12-19-10-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze-editor/extensions",
+      "comment": "aysnc language sytax colorization",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@coze-editor/extensions",
+  "email": "hanchayi@163.com"
+}

--- a/packages/text-editor/extensions/src/brackets/colorization.ts
+++ b/packages/text-editor/extensions/src/brackets/colorization.ts
@@ -8,7 +8,7 @@ import {
   type ViewUpdate,
   type DecorationSet,
 } from '@codemirror/view';
-import { syntaxTree } from '@codemirror/language';
+import { syntaxTree, language } from '@codemirror/language';
 
 const DEFAULT_COLORS = ['#ffd700', '#da70d6', '#179fff'];
 
@@ -21,12 +21,21 @@ const ColorizationBracketsPlugin = ViewPlugin.fromClass(
     }
 
     update(update: ViewUpdate) {
-      if (update.docChanged || update.selectionSet || update.viewportChanged) {
+      if (
+        update.docChanged ||
+        update.selectionSet ||
+        update.viewportChanged ||
+        update.state.facet(language) !== update.startState.facet(language)
+      ) {
         this.decorations = this.getBracketDecorations(update.view);
       }
     }
 
     getBracketDecorations(view: EditorView) {
+      if (!view.state.facet(language)) {
+        return Decoration.none;
+      }
+
       const { doc } = view.state;
       const decorations: any[] = [];
       const stack: { type: string; from: number }[] = [];


### PR DESCRIPTION
### 修改点
- 修复异步加载语言包首次进入注释中括号颜色

### 现象
- 首次进入时 注释中的 {} 始终有颜色，变更或者选中才变成注释的颜色

![20251219182040_rec_](https://github.com/user-attachments/assets/f96b0579-7254-4973-952c-22f69b8d7a7c)


### 根因
- 由于语言包是异步加载的，首次进入syntaxTree还没有所以没法根据语法树中的类型去屏蔽注释颜色



