### PR TITLE
feat: remove value option and add ValueSync, add options.reset

### DIFF
--- a/common/changes/@coze-editor/core-plugins/fix-reset-language_2025-12-19-11-04.json
+++ b/common/changes/@coze-editor/core-plugins/fix-reset-language_2025-12-19-11-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze-editor/core-plugins",
+      "comment": "remove value option and add ValueSync, add options.reset for asyncOption",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@coze-editor/core-plugins",
+  "email": "stream-pipe@users.noreply.github.com"
+}

--- a/common/changes/@coze-editor/core/fix-reset-language_2025-12-19-11-04.json
+++ b/common/changes/@coze-editor/core/fix-reset-language_2025-12-19-11-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze-editor/core",
+      "comment": "remove value option and add ValueSync, add options.reset for asyncOption",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@coze-editor/core",
+  "email": "stream-pipe@users.noreply.github.com"
+}

--- a/common/changes/@coze-editor/extensions/fix-reset-language_2025-12-19-11-04.json
+++ b/common/changes/@coze-editor/extensions/fix-reset-language_2025-12-19-11-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze-editor/extensions",
+      "comment": "remove value option and add ValueSync, add options.reset for asyncOption",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@coze-editor/extensions",
+  "email": "stream-pipe@users.noreply.github.com"
+}

--- a/common/changes/@coze-editor/preset-code-languages/fix-reset-language_2025-12-19-11-04.json
+++ b/common/changes/@coze-editor/preset-code-languages/fix-reset-language_2025-12-19-11-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze-editor/preset-code-languages",
+      "comment": "remove value option and add ValueSync, add options.reset for asyncOption",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@coze-editor/preset-code-languages",
+  "email": "stream-pipe@users.noreply.github.com"
+}

--- a/common/changes/@coze-editor/preset-universal/fix-reset-language_2025-12-19-11-04.json
+++ b/common/changes/@coze-editor/preset-universal/fix-reset-language_2025-12-19-11-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze-editor/preset-universal",
+      "comment": "remove value option and add ValueSync, add options.reset for asyncOption",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@coze-editor/preset-universal",
+  "email": "stream-pipe@users.noreply.github.com"
+}

--- a/common/changes/@coze-editor/react-components/fix-reset-language_2025-12-19-11-04.json
+++ b/common/changes/@coze-editor/react-components/fix-reset-language_2025-12-19-11-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze-editor/react-components",
+      "comment": "remove value option and add ValueSync, add options.reset for asyncOption",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@coze-editor/react-components",
+  "email": "stream-pipe@users.noreply.github.com"
+}

--- a/packages/text-editor/core-plugins/src/option.ts
+++ b/packages/text-editor/core-plugins/src/option.ts
@@ -1,15 +1,9 @@
 //  Copyright (c) 2025 coze-dev
 //  SPDX-License-Identifier: MIT
 
-import { FacetCombineStrategy } from '@coze-editor/utils';
 import { placeholder as cmPlaceholder } from '@coze-editor/extension-placeholder';
-import {
-  EditorView,
-  ViewPlugin,
-  type ViewUpdate,
-  lineNumbers as cmLineNumbers,
-} from '@codemirror/view';
-import { EditorState, Facet, Prec } from '@codemirror/state';
+import { EditorView, lineNumbers as cmLineNumbers } from '@codemirror/view';
+import { EditorState, Prec } from '@codemirror/state';
 
 export const fontSize = (value?: number) => {
   if (typeof value === 'undefined') {
@@ -146,32 +140,3 @@ export const lineNumbers = (enable?: boolean) =>
 
 export const lineWrapping = (enable: boolean) =>
   enable ? EditorView.lineWrapping : [];
-
-const valueFacet = Facet.define<string, string>({
-  combine: FacetCombineStrategy.Last,
-});
-export const valueExtension = ViewPlugin.fromClass(
-  class {
-    update(update: ViewUpdate) {
-      const currentValue = update.state.doc.toString();
-      const newValue = update.state.facet(valueFacet);
-
-      if (
-        typeof newValue === 'string' &&
-        newValue &&
-        newValue !== currentValue
-      ) {
-        queueMicrotask(() => {
-          update.view.dispatch({
-            changes: {
-              from: 0,
-              to: currentValue.length,
-              insert: newValue,
-            },
-          });
-        });
-      }
-    }
-  },
-);
-export const value = (v: string) => valueFacet.of(v);

--- a/packages/text-editor/dev/src/pages/highlight/examples.tsx
+++ b/packages/text-editor/dev/src/pages/highlight/examples.tsx
@@ -17,6 +17,7 @@ function App() {
   return (
     <div>
       <h1>Hello World</h1>
+      {/* hello() */}
     </div>
   );
 }
@@ -31,6 +32,7 @@ export default App;
 function App() {
   return (
     <div>
+      {/* hello() */}
       <h1>Hello World</h1>
     </div>
   );
@@ -51,6 +53,7 @@ export default App;
 </head>
 <body>
   <h1>Hello World</h1>
+  <!-- hello() -->
 </body>
 </html>
 `,
@@ -83,7 +86,7 @@ This is a markdown example.
     path: 'a.md',
   },
   {
-    code: 'const a = 1;',
+    code: 'const a = (1);',
     path: 'a.js',
   },
   {

--- a/packages/text-editor/dev/src/pages/highlight/index.tsx
+++ b/packages/text-editor/dev/src/pages/highlight/index.tsx
@@ -3,18 +3,19 @@ import universalCode from '@coze-editor/editor/preset-universal-code';
 import autoLanguage from '@coze-editor/editor/preset-code-languages';
 import { useState } from 'react';
 import { examples } from './examples';
-import { createEditor } from '@coze-editor/editor/react';
+import { createEditor, ValueSync } from '@coze-editor/editor/react';
 
-const CodeHighlight = createEditor(
-  [...universal, ...universalCode, ...autoLanguage],
-  {
-    defaultOptions: {
-      fontSize: 15,
-      readOnly: true,
-      editable: false,
-    },
-  },
-);
+const CodeHighlight = createEditor([
+  ...universal,
+  ...universalCode,
+  ...autoLanguage,
+], {
+  defaultOptions: {
+    fontSize: 15,
+    readOnly: true,
+    editable: false,
+  }
+})
 
 const HighlightPage = () => {
   const [code, setCode] = useState('const a = 1;');
@@ -46,14 +47,15 @@ const HighlightPage = () => {
           },
         }}
         options={{
-          value: code,
           path: path,
           activeLine: false,
         }}
         didMount={api => {
           console.log('didMount', api);
         }}
-      />
+      >
+        <ValueSync value={code}></ValueSync>
+      </CodeHighlight>
     </div>
   );
 };

--- a/packages/text-editor/extensions/src/brackets/colorization.ts
+++ b/packages/text-editor/extensions/src/brackets/colorization.ts
@@ -39,7 +39,12 @@ const ColorizationBracketsPlugin = ViewPlugin.fromClass(
       const { doc } = view.state;
       const decorations: any[] = [];
       const stack: { type: string; from: number }[] = [];
-      const limitNodeType = ['Comment', 'String', 'LineComment'];
+      const limitNodeType = [
+        'Comment',
+        'String',
+        'LineComment',
+        'BlockComment',
+      ];
 
       const tree = syntaxTree(view.state);
 

--- a/packages/text-editor/preset-code-languages/src/preset.ts
+++ b/packages/text-editor/preset-code-languages/src/preset.ts
@@ -3,5 +3,7 @@ import { asyncOption } from '@coze-editor/core';
 import { getLanguage } from './languages';
 
 export const preset = [
-  ...asyncOption('path', async (path: string) => getLanguage(path)),
+  ...asyncOption('path', (path: string) => getLanguage(path), {
+    reset: true,
+  }),
 ];

--- a/packages/text-editor/preset-universal/src/index.ts
+++ b/packages/text-editor/preset-universal/src/index.ts
@@ -30,8 +30,6 @@ import {
   transformTextInSelection,
   getLineInfoAtPosition,
   getSelection,
-  valueExtension,
-  value,
 } from '@coze-editor/core-plugins';
 import {
   option,
@@ -53,8 +51,6 @@ const preset = [
   option('height', height),
   option('minHeight', minHeight),
   option('maxHeight', maxHeight),
-  extension(valueExtension),
-  option('value', value),
 
   api('getValue', getValue),
   api('setValue', setValue),

--- a/packages/text-editor/react-components/src/index.ts
+++ b/packages/text-editor/react-components/src/index.ts
@@ -47,3 +47,5 @@ export {
 } from './embeded-line-view';
 
 export { PrefixElement } from './prefix-element';
+
+export { ValueSync } from './value-sync';

--- a/packages/text-editor/react-components/src/value-sync.tsx
+++ b/packages/text-editor/react-components/src/value-sync.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+
+import { type BuiltinEditorAPI, useEditor } from '@coze-editor/react';
+
+function ValueSync({ value }: { value: string }) {
+  const editor = useEditor<BuiltinEditorAPI | null>();
+
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+
+    const { doc } = editor.$view.state;
+    if (typeof value === 'string' && value !== doc.toString()) {
+      editor.$view.dispatch({
+        changes: {
+          from: 0,
+          to: doc.length,
+          insert: value,
+        },
+      });
+    }
+  }, [editor, value]);
+
+  return null;
+}
+
+export { ValueSync };


### PR DESCRIPTION
改动点：
- 移除 value 配置
- 增加 ValueSync 组件用于替代 value 的功能
- 每次加载新语言时重置 language 为空，避免 code 更新，但是 language 未更新，使用了之前错误的 tree