### PR TITLE
fix(editor): fix caret issue with PrefixElement

### DIFF
--- a/common/changes/@coze-editor/react-components/fix-prefix-element-caret_2026-06-17-11-51.json
+++ b/common/changes/@coze-editor/react-components/fix-prefix-element-caret_2026-06-17-11-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze-editor/react-components",
+      "comment": "fix caret issue with PrefixElement",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@coze-editor/react-components",
+  "email": "stream-pipe@users.noreply.github.com"
+}

--- a/packages/text-editor/dev/src/index.tsx
+++ b/packages/text-editor/dev/src/index.tsx
@@ -1,5 +1,5 @@
 import { createRoot } from 'react-dom/client';
-import Page from './pages/highlight';
+import Page from './pages/prefix';
 import './index.css';
 
 createRoot(document.getElementById('app')!).render(<Page />);

--- a/packages/text-editor/react-components/src/prefix-element/dom.ts
+++ b/packages/text-editor/react-components/src/prefix-element/dom.ts
@@ -18,11 +18,6 @@ function textRange(node: Text, from: number, to = from) {
   return range;
 }
 
-function flattenRect(rect: Rect, left: boolean) {
-  const x = left ? rect.left : rect.right;
-  return { left: x, right: x, top: rect.top, bottom: rect.bottom };
-}
-
 function clientRectsFor(dom: Node) {
   if (dom.nodeType == 3) {
     return textRange(dom as Text, 0, dom.nodeValue!.length).getClientRects();
@@ -33,6 +28,6 @@ function clientRectsFor(dom: Node) {
   }
 }
 
-export { flattenRect, clientRectsFor };
+export { clientRectsFor };
 
 export type { Rect };

--- a/packages/text-editor/react-components/src/prefix-element/react.tsx
+++ b/packages/text-editor/react-components/src/prefix-element/react.tsx
@@ -5,7 +5,7 @@ import { useHTMLElement, useLatest } from '@coze-editor/react-hooks';
 import { useInjector } from '@coze-editor/react';
 import { Decoration, EditorView, keymap, WidgetType } from '@codemirror/view';
 
-import { clientRectsFor, flattenRect } from './dom';
+import { clientRectsFor } from './dom';
 
 class PrefixElementWidget extends WidgetType {
   constructor(
@@ -43,7 +43,7 @@ class PrefixElementWidget extends WidgetType {
       return null;
     }
     const style = window.getComputedStyle(dom.parentNode as HTMLElement);
-    const rect = flattenRect(rects[0], style.direction != 'rtl');
+    const rect = rects[0];
     const lineHeight = parseInt(style.lineHeight);
     if (rect.bottom - rect.top > lineHeight * 1.5) {
       return {


### PR DESCRIPTION
改动点：
- 修复：使用 PrefixElement 后，如果输入内容，再删除内容，光标会跑到 PrefixElement 前面，预期光标仍然在 PrefixElement 后面